### PR TITLE
Remove references to edX from Onboarding Course

### DIFF
--- a/html/first_steps_as_a_core_team_member_edx_accessibility_training_course_1.html
+++ b/html/first_steps_as_a_core_team_member_edx_accessibility_training_course_1.html
@@ -1,7 +1,0 @@
-<p>
-  Complete the
-  <a href="https://edge.edx.org/courses/course-v1:edX+AC101+2016/about" target="_blank">edX Accessibility Training Course</a>.
-  Use your @edx.org address to register and complete all sections
-  (this is a legal requirement for edX). Log the time spent on this on
-  <a href="https://tasks.opencraft.com/browse/OC-1843" target="_blank">OC-1843</a>.
-</p>

--- a/html/first_steps_as_a_core_team_member_edx_accessibility_training_course_1.xml
+++ b/html/first_steps_as_a_core_team_member_edx_accessibility_training_course_1.xml
@@ -1,1 +1,0 @@
-<html filename="first_steps_as_a_core_team_member_edx_accessibility_training_course_1"/>

--- a/html/first_steps_as_a_core_team_member_your_picture_1.html
+++ b/html/first_steps_as_a_core_team_member_your_picture_1.html
@@ -1,5 +1,0 @@
-<p>
-  Send a head shot picture of yourself to Xavier - edX has a wall at
-  their office where they display photos of all employees and contractors working
-  on the project.
-</p>

--- a/html/first_steps_as_a_core_team_member_your_picture_1.xml
+++ b/html/first_steps_as_a_core_team_member_your_picture_1.xml
@@ -1,1 +1,0 @@
-<html filename="first_steps_as_a_core_team_member_your_picture_1"/>

--- a/html/github_configuration_publicizing_your_e-mail_1.html
+++ b/html/github_configuration_publicizing_your_e-mail_1.html
@@ -1,7 +1,0 @@
-<p>
-  Please make sure you publicize your email in commits (i.e. ensure that in
-  <a href="https://github.com/settings/profile" target="_blank">Github settings</a>
-  &gt; Public email, you have an email selected - this is used in merge commits,
-  which are collected by a bot which pings developers for feature verification
-  as part of edX's weekly release process)
-</p>

--- a/html/github_configuration_publicizing_your_e-mail_1.xml
+++ b/html/github_configuration_publicizing_your_e-mail_1.xml
@@ -1,1 +1,0 @@
-<html filename="github_configuration_publicizing_your_e-mail_1"/>

--- a/html/github_configuration_publicizing_your_github_membership_1.html
+++ b/html/github_configuration_publicizing_your_github_membership_1.html
@@ -1,6 +1,7 @@
 <p>
   Please
   <a href="https://help.github.com/articles/publicizing-or-hiding-organization-membership/" target="_blank">publicize your membership</a>
-  in both the OpenCraft and edX organizations, once you get granted access.
-  This is necessary to trigger builds for pull requests on Jenkins.
+  in the OpenCraft GitHub organization, once you get granted access.
+  This is necessary so you'll have permission to trigger Jenkins CI builds
+  for pull requests against the upstream edx-platform repository.
 </p>

--- a/html/open_edx_devstack_installation_2.html
+++ b/html/open_edx_devstack_installation_2.html
@@ -5,12 +5,8 @@
   or
   <a href="https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/60227787/Running+Devstack" target="_blank">complete explanations</a>.
   Also, look for posts about the issue on
-  <a href="https://groups.google.com/forum/#!forum/edx-code" target="_blank">edx-code</a>, ask on Mattermost, ask on the
-  <em>dev</em>
-  channel on edX's HipChat (best, but you may not have access yet),
-  and/or ask on the
-  <em>#general</em>
-  channel on edX's Slack (please see
+  <a href="https://groups.google.com/forum/#!forum/edx-code" target="_blank">edx-code</a>, ask on Mattermost,
+  and/or ask on the <em>#general</em> channel on edX's Slack (please see
   <a href="https://github.com/open-craft/documentation/blob/master/OpenCraft.md#tools-we-use" target="_blank">Tools we use</a>
   for access info).
 </p>

--- a/html/open_edx_documentation_building_and_running_an_edx_course_1.html
+++ b/html/open_edx_documentation_building_and_running_an_edx_course_1.html
@@ -1,5 +1,5 @@
 <p>
   Please skim through through the
   <a href="http://edx.readthedocs.org/projects/edx-partner-course-staff/en/latest/getting_started/index.html" target="_blank">Building and Running an edX Course</a>
-  docs to get grasp of the terminology specific to edX.
+  docs to get a grasp of the terminology specific to edX.
 </p>

--- a/html/opencraft_email_accounts_and_mailing_lists_account_on_edx_jira_1.html
+++ b/html/opencraft_email_accounts_and_mailing_lists_account_on_edx_jira_1.html
@@ -1,3 +1,15 @@
 <p>
-  Please create an account with your @opencraft.com e-mail on <a href="https://openedx.atlassian.net" target="_blank">edX JIRA</a>.
+  Please <a href="https://id.atlassian.com/signup">create an Atlassian account</a> with your @opencraft.com e-mail.
+  You should use this email for any JIRA or Atlassian Wiki that you need to access, other than
+  OpenCraft's own JIRA which does not use Atlassian accounts.
 </p>
+<p>
+  For example, here is a list of JIRA sites we often use. If you take on a task that requires access
+  to one of these sites, be sure to log in using your new @opencraft.com Atlassian Account.
+</p>
+<ul>
+  <li><a href="https://openedx.atlassian.net" target="_blank">Open edX JIRA, openedx.atlassian.net</a> (this is the only one that allows public registrations)</li>
+  <li><a href="https://edx-wiki.atlassian.net" target="_blank">McKinsey Academy JIRA, edx-wiki.atlassian.net</a></li>
+  <li><a href="https://mckinseyacademy.atlassian.net/wiki/" target="_blank">McKinsey Academy Wiki, mckinseyacademy.atlassian.net</a></li>
+  <li><a href="https://lnet-jira.atlassian.net/secure/RapidBoard.jspa?rapidView=35" target="_blank">Campus JIRA, lnet-jira.atlassian.net</a></li>
+</ul>

--- a/html/opencraft_email_accounts_and_mailing_lists_avatars_1.html
+++ b/html/opencraft_email_accounts_and_mailing_lists_avatars_1.html
@@ -1,6 +1,4 @@
 <p>
   Please set up a custom avatar on
   <a href="https://tasks.opencraft.com/secure/ViewProfile.jspa" target="_blank">our JIRA</a>.
-  Do it also on
-  <a href="https://openedx.atlassian.net/secure/ViewProfile.jspa" target="_blank">edX JIRA</a>.
 </p>

--- a/html/opencraft_email_accounts_and_mailing_lists_edx_account_1.html
+++ b/html/opencraft_email_accounts_and_mailing_lists_edx_account_1.html
@@ -1,9 +1,0 @@
-<p>
-  Most OpenCraft team members will also have access to an @edx.org Gmail account.
-  The main purpose of this is just to allow us to access Google Docs
-  that are shared with
-  <em>anyone in the edx.org organization</em>.
-  The @edx.org email should not be publicized or used to send mail.
-  It should be configured to forward all incoming mail
-  to your @opencraft.com address, to make sure you don't miss anything.
-</p>

--- a/html/opencraft_email_accounts_and_mailing_lists_edx_account_1.xml
+++ b/html/opencraft_email_accounts_and_mailing_lists_edx_account_1.xml
@@ -1,1 +1,0 @@
-<html filename="opencraft_email_accounts_and_mailing_lists_edx_account_1"/>

--- a/html/opencraft_email_accounts_and_mailing_lists_student_accounts_on_edxorg_1.html
+++ b/html/opencraft_email_accounts_and_mailing_lists_student_accounts_on_edxorg_1.html
@@ -1,7 +1,0 @@
-<p>
-  Please register and activate student accounts on
-  <a href="https://courses.edx.org/register" target="_blank">edx.org</a>
-  and
-  <a href="https://edge.edx.org/register" target="_blank">edge.edx.org</a>
-  using your @opencraft.com e-mail.
-</p>

--- a/html/opencraft_email_accounts_and_mailing_lists_student_accounts_on_edxorg_1.xml
+++ b/html/opencraft_email_accounts_and_mailing_lists_student_accounts_on_edxorg_1.xml
@@ -1,1 +1,0 @@
-<html filename="opencraft_email_accounts_and_mailing_lists_student_accounts_on_edxorg_1"/>

--- a/html/pull_requests_sandboxes_1.html
+++ b/html/pull_requests_sandboxes_1.html
@@ -1,6 +1,6 @@
 <p>
   We do also use sandboxes. Please read
-  <a href="https://github.com/open-craft/documentation/blob/master/sandboxes_howto.md" target="_blank">Sandboxes' HOWTO</a>
+  <a href="https://github.com/open-craft/documentation/blob/master/sandboxes_howto.md" target="_blank">Sandboxes HOWTO</a>
   to learn how to work with sandboxes, which help reviewers test your code.
 </p>
 <p>

--- a/html/whats_expected_admin_1.html
+++ b/html/whats_expected_admin_1.html
@@ -1,6 +1,5 @@
 <p>
-  My duties as an
-  <strong>admin</strong>are:
+  My duties as an <strong>admin</strong> are:
 </p>
 <ul>
   <ul>

--- a/html/whats_expected_code_reviewer_1.html
+++ b/html/whats_expected_code_reviewer_1.html
@@ -1,10 +1,9 @@
 <p>
-  As a
-  <strong>code reviewer</strong>:
+  As a <strong>code reviewer</strong>:
 </p>
 <ol>
   <li>
-    will give prompt, thoughtful, thorough, constructive code reviews.
+    I will give prompt, thoughtful, thorough, constructive code reviews.
   </li>
   <li>
     (When reviewing OpenCraft work): I will expect that the PR author

--- a/html/whats_expected_sprint_firefighter_1.html
+++ b/html/whats_expected_sprint_firefighter_1.html
@@ -54,7 +54,7 @@
       Complete any personal spillover from the previous sprint
     </li>
     <li>
-      Being in Hipchat (#dev) and Slack(#general), answering questions &amp;
+      Being available on the Open edX Slack (#general), answering questions and
       responding to emergencies reported there (log time on OC-1017)
     </li>
     <li>

--- a/sequential/first_steps_as_a_core_team_member.xml
+++ b/sequential/first_steps_as_a_core_team_member.xml
@@ -2,7 +2,5 @@
   <vertical url_name="first_steps_as_a_core_team_member_date_of_birth"/>
   <vertical url_name="first_steps_as_a_core_team_member_mckinsey"/>
   <vertical url_name="first_steps_as_a_core_team_member_secrets_and_keepass"/>
-  <vertical url_name="first_steps_as_a_core_team_member_edx_accessibility_training_course"/>
-  <vertical url_name="first_steps_as_a_core_team_member_your_picture"/>
   <vertical url_name="first_steps_as_a_core_team_member_mailing_lists"/>
 </sequential>

--- a/sequential/github_configuration.xml
+++ b/sequential/github_configuration.xml
@@ -1,6 +1,5 @@
 <sequential display_name="GitHub configuration">
   <vertical url_name="github_configuration_introduction"/>
-  <vertical url_name="github_configuration_publicizing_your_e-mail"/>
   <vertical url_name="github_configuration_showing_a_real_name"/>
   <vertical url_name="github_configuration_publicizing_your_github_membership"/>
   <vertical url_name="github_configuration_activating_2-factor_authentication"/>

--- a/sequential/opencraft_email_accounts_and_mailing_lists.xml
+++ b/sequential/opencraft_email_accounts_and_mailing_lists.xml
@@ -5,8 +5,6 @@
   <vertical url_name="opencraft_email_accounts_and_mailing_lists_using_google_drive"/>
   <vertical url_name="opencraft_email_accounts_and_mailing_lists_mailing_the_whole_team"/>
   <vertical url_name="opencraft_email_accounts_and_mailing_lists_notifications"/>
-  <vertical url_name="opencraft_email_accounts_and_mailing_lists_edx_account"/>
-  <vertical url_name="opencraft_email_accounts_and_mailing_lists_student_accounts_on_edxorg"/>
   <vertical url_name="opencraft_email_accounts_and_mailing_lists_mailing_lists"/>
   <vertical url_name="opencraft_email_accounts_and_mailing_lists_account_on_edx_jira"/>
   <vertical url_name="opencraft_email_accounts_and_mailing_lists_avatars"/>

--- a/vertical/first_steps_as_a_core_team_member_edx_accessibility_training_course.xml
+++ b/vertical/first_steps_as_a_core_team_member_edx_accessibility_training_course.xml
@@ -1,3 +1,0 @@
-<vertical display_name="edX Accessibility Training Course">
-  <html url_name="first_steps_as_a_core_team_member_edx_accessibility_training_course_1"/>
-</vertical>

--- a/vertical/first_steps_as_a_core_team_member_your_picture.xml
+++ b/vertical/first_steps_as_a_core_team_member_your_picture.xml
@@ -1,3 +1,0 @@
-<vertical display_name="Your picture">
-  <html url_name="first_steps_as_a_core_team_member_your_picture_1"/>
-</vertical>

--- a/vertical/github_configuration_publicizing_your_e-mail.xml
+++ b/vertical/github_configuration_publicizing_your_e-mail.xml
@@ -1,3 +1,0 @@
-<vertical display_name="Publicizing your e-mail">
-  <html url_name="github_configuration_publicizing_your_e-mail_1"/>
-</vertical>

--- a/vertical/opencraft_email_accounts_and_mailing_lists_edx_account.xml
+++ b/vertical/opencraft_email_accounts_and_mailing_lists_edx_account.xml
@@ -1,3 +1,0 @@
-<vertical display_name="edX account">
-  <html url_name="opencraft_email_accounts_and_mailing_lists_edx_account_1"/>
-</vertical>

--- a/vertical/opencraft_email_accounts_and_mailing_lists_student_accounts_on_edxorg.xml
+++ b/vertical/opencraft_email_accounts_and_mailing_lists_student_accounts_on_edxorg.xml
@@ -1,3 +1,0 @@
-<vertical display_name="Student accounts on edx.org">
-  <html url_name="opencraft_email_accounts_and_mailing_lists_student_accounts_on_edxorg_1"/>
-</vertical>


### PR DESCRIPTION
Changes include:
* Fixed some minor typos and grammar issues
* Remove reference to @edx.org Google accounts
* Removed requirement for "publicize your email in commits" (edX has not been doing feature verification since they changed from weekly releases to daily continuous deployment).
* Removed "Please register and activate student accounts on edx.org and edge.edx.org using your @opencraft.com e-mail."
* Remove reference to edX a11y training course (we won't have access to that in the future)
* Remove requirement to send headshot for edX wall
* Recommended creating a single Atlassian cloud account for use on all external JIRA/Confluence sites.

To preview: download https://github.com/open-craft/courses/archive/onboarding-sin-edx.tar.gz . Or, I have imported the course to https://courses.opencraft.com/courses/course-v1:OpenCraft+onboarding-dev+course/ (and set "Visibility in Catalog" to "none" and "Invitation Only" to "true" to make it hidden+private), so you can also just preview it there.

JIRA: OC-3431