### PR TITLE
Fix issues in 1-to-1 meeting content.

### DIFF
--- a/html/getting_to_know_everyone_setup_meetings_1.html
+++ b/html/getting_to_know_everyone_setup_meetings_1.html
@@ -1,5 +1,5 @@
 <p>
-    Setting up the actual meetings can be challenge when people are working 
+    Setting up the actual meetings can be a challenge when people are working 
     from different timezones and have vastly different schedules. You can ping
     people any way you want, preferring asynchronous means to avoid the need
     for instant replies. 
@@ -9,7 +9,9 @@
     The email should mention the task you've created, so they know where to log
     the time, and remember to mention your timezone and availability in UTC. 
     Do this as early in the sprint as possible so people have time to respond 
-    and figure out the time that suits them best. 
+    and figure out the time that suits them best. Once you've scheduled all
+    the meetings, you can mark this task as merged while the meetings continue
+    over multiple sprints. 
 </p>
 <p>
     You can also ping people on the JIRA ticket itself. This should 
@@ -22,4 +24,7 @@
     <a href="https://calendly.com/">Calendly</a> can be useful while scheduling
     them. It lets you define your availability and share a link that lets 
     invitees select a free time-slot on your calendar that suits them as well.
+    If you find this useful, you can ask 
+    <a href="mailto:xavier@opencraft.com">Xavier</a>, and he will set you up 
+    with an account at OpenCraft's expense there.
 </p>


### PR DESCRIPTION
This PR includes the following changes based on the [previous PR's](#14) review:
* Fix typo
* Mention setting up Calendly at OpenCraft's expense
* Mention that the meeting task can be merged after scheduling the meetings

**Reviewers**
- [ ] @antoviaque 