### PR TITLE
Adapt documentation to two-week sprints.

### DIFF
--- a/html/opencraft_opencraft_process_2.html
+++ b/html/opencraft_opencraft_process_2.html
@@ -1,11 +1,16 @@
 <ol>
   <li>
-    Every Friday &amp; Monday, everyone on the team collaboratively
-    and asynchronously plans who will work on what tasks for the upcoming week.
+    We work in two-week sprints.
   </li>
   <li>
-    We have a meeting every Monday, where we do a final review of the plans
-    for the upcoming sprint, then start the sprint.
+    On Friday &amp; Monday at the end of a sprint, everyone on the team collaboratively
+    and asynchronously plans who will work on what tasks for the upcoming sprint.
+  </li>
+  <li>
+    We have a meeting every Monday.  If it's the beginning of a new sprint, we do a final
+    review of the plans for the upcoming sprint, then start the sprint.  If it's the middle
+    of a sprint, we try to ensure everything is going smoothly, and discuss how to help with
+    tasks that are at risk of not being finished by the end of the sprint.
   </li>
   <li>
     After that, tasks move from left to right until completion on our JIRA tracker.

--- a/html/opencraft_ticket_statuses_3.html
+++ b/html/opencraft_ticket_statuses_3.html
@@ -1,7 +1,7 @@
 <p>
   <strong>This week</strong>:
   This is the list of tasks assigned to individuals and
-  expected to be finished by the end of the week.
+  expected to be finished by the end of the sprint.
 </p>
 <p>
   Once you start working

--- a/html/opencraft_ticket_statuses_6.html
+++ b/html/opencraft_ticket_statuses_6.html
@@ -4,7 +4,7 @@
   that are waiting on something (like a code review) from anyone outside of OpenCraft.
 </p>
 <p>
-  Ideally, all Pull Requests should reach this state ahead of the end of the week
+  Ideally, all Pull Requests should reach this state ahead of the end of the sprint
   to leave time for reviewing and corrections.
   <br />
   These tasks are usually awaiting the owner of an upstream repo to review
@@ -17,6 +17,6 @@
   If you (the assignee) do not expect any progress on the ticket
   in the upcoming sprint, you should move the ticket to the
   "Long External Review/Blocked" sprint, so that it won't be cluttering up the
-  weekly sprint board and so that your commitments for the upcoming sprint are
+  sprint board and so that your commitments for the upcoming sprint are
   more certain.
 </p>

--- a/html/whats_expected_epic_owner_1.html
+++ b/html/whats_expected_epic_owner_1.html
@@ -19,7 +19,8 @@
   </li>
   <li>
     <p>
-      On Friday, I will post an epic update that answers these questions:
+      On Thursday in the second week of a sprint, I will post an epic update
+      that answers these questions:
     </p>
   </li>
 </ol>

--- a/html/whats_expected_opencraft_team_member_4.html
+++ b/html/whats_expected_opencraft_team_member_4.html
@@ -62,6 +62,9 @@
     If necessary, I will work overtime to complete my tasks before the end of the sprint.
   </li>
   <li>
+    I will prioritise stories that spilled over from the previous sprint.
+  </li>
+  <li>
     I will "work from the right", prioritizing responding to external reviews
     as the highest priority, then doing reviews / responding to questions
     from others on the team, and finally working on implementing my own "In Progress" tasks.

--- a/html/whats_expected_opencraft_team_member_4.html
+++ b/html/whats_expected_opencraft_team_member_4.html
@@ -1,5 +1,5 @@
 <h4>
-  Weekly sprint tasks
+  Sprint tasks
 </h4>
 <ol>
   <li>
@@ -30,23 +30,25 @@
     </ul>
   </li>
   <li>
-    I will only commit to work each week that I believe I can comfortably complete
-    within the allotted sprint time (one week).
+    I will only commit to work each sprint that I believe I can comfortably complete
+    within the allotted sprint time (two weeks).
     Here, "complete" means "get merged or to external review."
   </li>
   <li>
     I will get all of my tasks ready for internal review (by someone else
     on the OpenCraft team) by the
-    <strong>end of Thursday</strong>
+    <strong>end of Thursday in the second week of the sprint</strong>
     at the latest. This will ensure that there is time for the review to take place,
     and for me to address the review comments
-    and get the internal reviewer's approval in time.
+    and get the internal reviewer's approval in time.  If a ticket potentially requires multiple
+    review cycles, get it into review as early as possible.  Schedule reviews with your reviewer
+    to make sure they have time when you get your work ready for review.
   </li>
   <li>
     I will get my tasks to at least
     <strong>External Review</strong>
     (or "Merged" if no external review is required) by
-    <strong>one hour before the weekly sprint planning meeting</strong>.
+    <strong>one hour before the sprint planning meeting for the next sprint</strong>.
     As this is also dependent on the internal reviewer,
     I'll make sure she/he will be available around the time I finish.
   </li>
@@ -70,7 +72,7 @@
     if I have time and they are overloaded.
   </li>
   <li>
-    Once a week, I will review all of my tasks that are in "Long External Review/Blocked"
+    Once a sprint, I will review all of my tasks that are in "Long External Review/Blocked"
     and if needed, I will ping the external reviewer/blocker or pull the task into
     an upcoming sprint.
   </li>

--- a/html/whats_expected_opencraft_team_member_4.html
+++ b/html/whats_expected_opencraft_team_member_4.html
@@ -37,7 +37,7 @@
   <li>
     I will get all of my tasks ready for internal review (by someone else
     on the OpenCraft team) by the
-    <strong>end of Thursday in the second week of the sprint</strong>
+    <strong>end of Wednesday in the second week of the sprint</strong>
     at the latest. This will ensure that there is time for the review to take place,
     and for me to address the review comments
     and get the internal reviewer's approval in time.  If a ticket potentially requires multiple

--- a/html/whats_expected_someone_new_to_the_team_1.html
+++ b/html/whats_expected_someone_new_to_the_team_1.html
@@ -5,9 +5,10 @@
 <ol>
   <li>
     Not commit to more than 3 points of tasks during my first week,
-    or 5 points my second week. (It's really easy to over-commit at first,
+    or 5 points my second week (so no more than a total of 8 points for
+    the first sprint).  It's really easy to over-commit at first,
     so keep your commitments manageable. You can always take on more work
-    later in the sprint if you finish early.)
+    later in the sprint if you finish early.
   </li>
   <li>
     Provide lots of updates to my assigned reviewer/mentor for each task,

--- a/html/whats_expected_sprint_firefighter_1.html
+++ b/html/whats_expected_sprint_firefighter_1.html
@@ -54,12 +54,16 @@
       Complete any personal spillover from the previous sprint
     </li>
     <li>
-      Being available on the Open edX Slack (#general), answering questions and
-      responding to emergencies reported there (log time on OC-1017)
+      Work on client requests that can't wait until the next sprint, in particular in
+      the first week of a sprint.
     </li>
     <li>
-      Sprint ETA/Follow-up &amp; ensuring clean sprint
-      (helping to finish tickets if necessary)
+      Help ensuring a clean sprint by helping other team members, in particular in the
+      second week of a sprint.
+    </li>
+    <li>
+      Being available on the Open edX Slack (#general), answering questions and
+      responding to emergencies reported there (log time on OC-1017)
     </li>
     <li>
       Watch over sandboxes (ie keep an eye on the instance manager
@@ -83,7 +87,7 @@
     I will lead the meeting on Monday
   </li>
   <li>
-    On Wednesday at the end of the day, I will do a sprint checkin
+    On Friday or Monday well before the mid-sprint meeting, I will do a sprint checkin
     on all "backlog" and "In progress" tickets (this means to post a comment
     on each ticket to ask how the assignee is doing and if they need help,
     and/or asking them to update the status of the ticket if it is not clear).


### PR DESCRIPTION
This changes our on-boarding course to reflect the two-week sprint cycle trial.

I haven't changed _every_ mention of weekdays like Monday if it was clear from the context that only the Monday at the beginning of the sprint is meant.

See also https://github.com/open-craft/documentation/pull/258 for the changes to the meetings agenda.